### PR TITLE
ECSリソース環境を作成(terraform plan成功まで)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,74 @@ https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform
 
 ## Setup
 
-1. touch variables.tf
-2. terraform init
+フォルダ階層はこんな感じになってます。
+
+```
+.
+├── README.md
+├── aws (プロバイダ名)
+│   ├── ecs (サービス名)
+│   │   ├── backend.tf (ステート管理設定)
+│   │   ├── modules (サービス名毎のリソース定義、変数定義、アウトプット定義)
+│   │   │   ├── `aws_service_name`.tf
+│   │   │   ├── outputs.tf
+│   │   │   └── variables.tf
+│   │   ├── provider.tf (プロバイダ定義)
+│   │   └── resources.tf (変数に用いる値を定義)
+│   └── vpc
+│       ├── backend.tf
+│       ├── env (これは使ってない。)
+│       │   ├── README.md
+│       │   ├── dev.tfvars
+│       │   ├── prod.tfvars
+│       │   └── stg.tfvars
+│       ├── modules
+│       │   ├── outputs.tf
+│       │   ├── variables.tf
+│       │   └── `aws_service_name`.tf
+│       ├── provider.tf
+│       └── resources.tf
+└── github
+    └── repository
+        └── main.tf
+```
+
+- `terraform init`までの作り方
+
+1. 適切なプロバイダ名、サービス名を決定してフォルダを作る
+2. `provider.tf`,`backend.tf`を作る。設定は既存サービスのものを参考に
+3. `terraform init`
+4. `terraform workspace new dev`
 
 ### backend
 
-`backend.tf`として記載
+基本AWS S3でステート管理。1.10から[S3単体でもロックが可能](https://github.com/hashicorp/terraform/pull/35661)になったのでそれを使ってます。
 
+```
+terraform {
+  backend "s3" {
+    bucket       = "nijipro-terraform"
+    key          = "aws/${service_name}/${service_name}.tfstate"
+    region       = "ap-northeast-1"
+    profile      = "terraform"
+    use_lockfile = true
+  }
+}
+```
+
+### provider
+
+プロバイダによって設定は変わります。AWSは以下
+
+```
+provider "aws" {
+  default_tags {
+    tags = {
+      Resource = "Terraform"
+    }
+  }
+}
+```
 
 ## Knowledge
 

--- a/aws/ecs/.terraform.lock.hcl
+++ b/aws/ecs/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.10.0"
+  hashes = [
+    "h1:ToB7wJhFPmcX1/0vbx5NgZAnP+cJ7Rti5NpNPyEJpxI=",
+    "zh:3c92efebaf635372bf7283e04fc667d59b0ff3cf1aacd011fc484a11f70954d9",
+    "zh:404b2a1d360851e63f25945406f2d0c2cb9c20b361552ce01bf7fe3df516a5bf",
+    "zh:523b1640e2b9e2b548876a1dccc627c290f342255d727568fe4becfd9a8f5689",
+    "zh:697adf10c76384195303650555229129d64135f5be3abf95da0bf4b6de742054",
+    "zh:69d6177e3e106518844373871d4e6377003336761aab884da32f66b034229b5c",
+    "zh:6a41899ce8ab9cdd6f706160fd350951e5f3fc1432a37e638d3576a780c686fd",
+    "zh:6e8fd28299d6bf0ab6922cf987757e578f357a45ac45abc312688580dbde3bee",
+    "zh:7ca4bfb5a8f89586dd0c8dd9c1e638a03bc7c6f456bcc29be57cfb7bdc90fc30",
+    "zh:8fe1f6e0a2718318bae3f53a4fb77bc9eaef0fc4131145996f48482b135830c6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b221cfbc9f19ad30719b773f05f45571e88b124c15c35ac230021df1bb1110f5",
+    "zh:b458c357b5f38092e374957e51827d9113447696deccf0cb01f5684d976e7725",
+    "zh:b7fbb1b05972d73d72af58a2179ac124c6d69a4f0392aa2ce4dc855e78f52268",
+    "zh:d95da0dc45df0f30005e17c5206addbd62b0471c265d9855fe8039bf6f2adef7",
+    "zh:db5dd4120c6ab6ae13df67353a9bc902ac34d01c1d297812d628ebf61dc6f681",
+  ]
+}

--- a/aws/ecs/backend.tf
+++ b/aws/ecs/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "nijipro-terraform"
+    key          = "aws/ecs/ecs.tfstate"
+    region       = "ap-northeast-1"
+    profile      = "terraform"
+    use_lockfile = true
+  }
+}

--- a/aws/ecs/modules/cluster.tf
+++ b/aws/ecs/modules/cluster.tf
@@ -1,6 +1,6 @@
 locals {
     ecs_cluster_tags = merge(
-        var.cluster_additional_tags,
+        var.additional_tags,
         {
             ServiceName = var.service_name
             Env = var.env

--- a/aws/ecs/modules/cluster.tf
+++ b/aws/ecs/modules/cluster.tf
@@ -1,0 +1,26 @@
+locals {
+    ecs_cluster_tags = merge(
+        var.cluster_additional_tags,
+        {
+            ServiceName = var.service_name
+            Env = var.env
+        }
+    )
+}
+
+resource "aws_ecs_cluster" "cluster" {
+    name = "${var.service_name}-${var.env}-cluster"
+    setting {
+        name = "containerInsights"
+        value = "enabled"
+    }
+    tags = local.ecs_cluster_tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "cluster_capacity_provider" {
+    cluster_name = aws_ecs_cluster.cluster.name
+
+    capacity_providers = [
+        "FARGATE"
+    ]
+}

--- a/aws/ecs/modules/cluster.tf
+++ b/aws/ecs/modules/cluster.tf
@@ -1,6 +1,6 @@
 locals {
     ecs_cluster_tags = merge(
-        var.additional_tags,
+        var.ecs_additional_tags,
         {
             ServiceName = var.service_name
             Env = var.env

--- a/aws/ecs/modules/outputs.tf
+++ b/aws/ecs/modules/outputs.tf
@@ -1,0 +1,7 @@
+output "ecs_cluster_name" {
+    value = aws_ecs_cluster.cluster.name
+}
+
+output "ecs_cluster_arn" {
+    value = aws_ecs_cluster.cluster.arn
+}

--- a/aws/ecs/modules/variables.tf
+++ b/aws/ecs/modules/variables.tf
@@ -1,0 +1,25 @@
+variable "service_name" {
+    type = string
+    description = "Service name"
+}
+
+variable "env" {
+    type = string
+    description = "Environment Identifier"
+
+    validation {
+        condition = contains(["dev", "stg", "prod"], var.env)
+        error_message = "Specify the environment identifier as 'dev', 'stg', or 'prod'."
+    }
+}
+
+variable "cluster_additional_tags" {
+    type = map(string)
+    default = {}
+    description = "Additional tags for the ECS Cluster"
+    validation {
+        condition = length(setintersection(keys(var.cluster_additional_tags),
+        ["ServiceName", "Env"])) == 0
+        error_message = "Key names, ServiceName and Env is reserved. Not allowed to use them."
+    }
+}

--- a/aws/ecs/modules/variables.tf
+++ b/aws/ecs/modules/variables.tf
@@ -13,12 +13,12 @@ variable "env" {
     }
 }
 
-variable "cluster_additional_tags" {
+variable "additional_tags" {
     type = map(string)
     default = {}
     description = "Additional tags for the ECS Cluster"
     validation {
-        condition = length(setintersection(keys(var.cluster_additional_tags),
+        condition = length(setintersection(keys(var.additional_tags),
         ["ServiceName", "Env"])) == 0
         error_message = "Key names, ServiceName and Env is reserved. Not allowed to use them."
     }

--- a/aws/ecs/modules/variables.tf
+++ b/aws/ecs/modules/variables.tf
@@ -13,12 +13,12 @@ variable "env" {
     }
 }
 
-variable "additional_tags" {
+variable "ecs_additional_tags" {
     type = map(string)
     default = {}
     description = "Additional tags for the ECS Cluster"
     validation {
-        condition = length(setintersection(keys(var.additional_tags),
+        condition = length(setintersection(keys(var.ecs_additional_tags),
         ["ServiceName", "Env"])) == 0
         error_message = "Key names, ServiceName and Env is reserved. Not allowed to use them."
     }

--- a/aws/ecs/provider.tf
+++ b/aws/ecs/provider.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      Resource = "Terraform"
+    }
+  }
+}

--- a/aws/ecs/resources.tf
+++ b/aws/ecs/resources.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source         = "./modules"
   service_name   = "terraform-ecs"
   env            = terraform.workspace
-  cluster_additional_tags = {
+  additional_tags = {
     Resource = "Terraform"
   }
 }

--- a/aws/ecs/resources.tf
+++ b/aws/ecs/resources.tf
@@ -2,7 +2,6 @@ module "vpc" {
   source         = "./modules"
   service_name   = "ecs"
   env            = terraform.workspace
-  additional_tags = {
-    Resource = "Terraform"
+  ecs_additional_tags = {
   }
 }

--- a/aws/ecs/resources.tf
+++ b/aws/ecs/resources.tf
@@ -1,0 +1,8 @@
+module "vpc" {
+  source         = "./modules"
+  service_name   = "terraform-ecs"
+  env            = terraform.workspace
+  cluster_additional_tags = {
+    Resource = "Terraform"
+  }
+}

--- a/aws/ecs/resources.tf
+++ b/aws/ecs/resources.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source         = "./modules"
-  service_name   = "terraform-ecs"
+  service_name   = "ecs"
   env            = terraform.workspace
   additional_tags = {
     Resource = "Terraform"

--- a/aws/ecs/resources.tf
+++ b/aws/ecs/resources.tf
@@ -1,7 +1,7 @@
 module "vpc" {
-  source         = "./modules"
-  service_name   = "ecs"
-  env            = terraform.workspace
+  source       = "./modules"
+  service_name = "ecs"
+  env          = terraform.workspace
   ecs_additional_tags = {
   }
 }

--- a/aws/vpc/env/dev.tfvars
+++ b/aws/vpc/env/dev.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr_block = "10.0.0.0/16"
 service_name = "terraform-vpc"
 env = "dev"
-vpc_additional_tags = {
+additional_tags = {
     Resource = "Terraform"
 }

--- a/aws/vpc/env/prod.tfvars
+++ b/aws/vpc/env/prod.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr_block = "10.0.0.0/16"
 service_name = "terraform-vpc"
 env = "prod"
-vpc_additional_tags = {
+additional_tags = {
     Resource = "Terraform"
 }

--- a/aws/vpc/env/stg.tfvars
+++ b/aws/vpc/env/stg.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr_block = "10.0.0.0/16"
 service_name = "terraform-vpc"
 env = "stga"
-vpc_additional_tags = {
+additional_tags = {
     Resource = "Terraform"
 }

--- a/aws/vpc/modules/variables.tf
+++ b/aws/vpc/modules/variables.tf
@@ -24,7 +24,7 @@ variable "env" {
     }
 }
 
-variable "vpc_additional_tags" {
+variable "additional_tags" {
     type = map(string)
     default = {}
     description = "Additional tags for the VPC"

--- a/aws/vpc/modules/variables.tf
+++ b/aws/vpc/modules/variables.tf
@@ -24,7 +24,7 @@ variable "env" {
     }
 }
 
-variable "additional_tags" {
+variable "vpc_additional_tags" {
     type = map(string)
     default = {}
     description = "Additional tags for the VPC"

--- a/aws/vpc/modules/variables.tf
+++ b/aws/vpc/modules/variables.tf
@@ -11,7 +11,7 @@ variable "vpc_cidr_block" {
 
 variable "service_name" {
     type = string
-    description = "VPC name"
+    description = "Service name"
 }
 
 variable "env" {

--- a/aws/vpc/modules/vpc.tf
+++ b/aws/vpc/modules/vpc.tf
@@ -3,7 +3,7 @@ resource "aws_vpc" "vpc" {
 
     # mergeは後から定義されたキーのバリューで上書きされるため、必須であるものを後ろに定義する
     tags = merge(
-        var.additional_tags,
+        var.vpc_additional_tags,
         {
             Name = var.service_name
             Env = var.env

--- a/aws/vpc/modules/vpc.tf
+++ b/aws/vpc/modules/vpc.tf
@@ -3,7 +3,7 @@ resource "aws_vpc" "vpc" {
 
     # mergeは後から定義されたキーのバリューで上書きされるため、必須であるものを後ろに定義する
     tags = merge(
-        var.vpc_additional_tags,
+        var.additional_tags,
         {
             Name = var.service_name
             Env = var.env

--- a/aws/vpc/resources.tf
+++ b/aws/vpc/resources.tf
@@ -17,7 +17,6 @@ module "vpc" {
         cidrsubnet(local.vpc_cidr, 6, 20),
     ]
   }
-  additional_tags = {
-    Resource = "Terraform"
+  vpc_additional_tags = {
   }
 }

--- a/aws/vpc/resources.tf
+++ b/aws/vpc/resources.tf
@@ -17,7 +17,7 @@ module "vpc" {
         cidrsubnet(local.vpc_cidr, 6, 20),
     ]
   }
-  vpc_additional_tags = {
+  additional_tags = {
     Resource = "Terraform"
   }
 }

--- a/aws/vpc/resources.tf
+++ b/aws/vpc/resources.tf
@@ -1,5 +1,5 @@
 locals {
-    vpc_cidr = "10.0.0.0/16"
+  vpc_cidr = "10.0.0.0/16"
 }
 
 module "vpc" {
@@ -9,12 +9,12 @@ module "vpc" {
   vpc_cidr_block = local.vpc_cidr
   subnet_cidrs = {
     public = [
-        cidrsubnet(local.vpc_cidr, 6, 1),
-        cidrsubnet(local.vpc_cidr, 6, 2),
+      cidrsubnet(local.vpc_cidr, 6, 1),
+      cidrsubnet(local.vpc_cidr, 6, 2),
     ]
     private = [
-        cidrsubnet(local.vpc_cidr, 6, 10),
-        cidrsubnet(local.vpc_cidr, 6, 20),
+      cidrsubnet(local.vpc_cidr, 6, 10),
+      cidrsubnet(local.vpc_cidr, 6, 20),
     ]
   }
   vpc_additional_tags = {

--- a/aws/vpc/resources.tf
+++ b/aws/vpc/resources.tf
@@ -4,7 +4,7 @@ locals {
 
 module "vpc" {
   source         = "./modules"
-  service_name   = "terraform-vpc"
+  service_name   = "vpc"
   env            = terraform.workspace
   vpc_cidr_block = local.vpc_cidr
   subnet_cidrs = {


### PR DESCRIPTION
- ECSリソース作成
- provider.tfとそれぞれservice_name.tfで定義するadditional_tagのタグ内容が被っていた為下流を削除
- service_name variableの値の最初に`terraform-`とつけるのをやめる

close #6 
close #5 
close #4 